### PR TITLE
Merge update to CI-macOS from develop

### DIFF
--- a/.github/workflows/testmacos.yml
+++ b/.github/workflows/testmacos.yml
@@ -5,18 +5,28 @@ on:
     branches:
       - main
       - master
+      - develop
   pull_request:
     branches:
       - main
       - master
+      - develop
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: macos-11
+            python-version: "3.7"
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
The workflows were previously successful with macOS and Python 3.7 months ago when a different runner was used. This issue now arises due to the unavailability of Python 3.7 for ARM64 architecture on macOS, which is where the runner `macos-latest` now points to. Using `macos-11` for Python 3.7 should resolve the problem, while the remaining will continue to use `macos-latest`.