### PR TITLE
Update GitHub Actions to Node.js 20 compatible versions

### DIFF
--- a/.github/workflows/testlinux.yml
+++ b/.github/workflows/testlinux.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/testmacos.yml
+++ b/.github/workflows/testmacos.yml
@@ -29,10 +29,10 @@ jobs:
             python-version: "3.10"
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/testwindows.yml
+++ b/.github/workflows/testwindows.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to use Node.js 20 instead of the deprecated Node.js 16 version. The following actions have been updated:

- actions/checkout@v3 -> actions/checkout@v4
- actions/setup-python@v4 -> actions/setup-python@v5